### PR TITLE
[Feature/#8] KeyChain을 통한 값 관리 객체 구현

### DIFF
--- a/Meme/Meme.xcodeproj/project.pbxproj
+++ b/Meme/Meme.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CC399992E2F831100D14084 /* KeyChainStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399982E2F831100D14084 /* KeyChainStorable.swift */; };
+		2CC3999A2E2F831100D14084 /* KeyChainStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399982E2F831100D14084 /* KeyChainStorable.swift */; };
 		2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
 		2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
 		2CE552382E268F9E004BE9AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552372E268F9E004BE9AF /* AppDelegate.swift */; };
@@ -48,6 +50,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2CC399982E2F831100D14084 /* KeyChainStorable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainStorable.swift; sourceTree = "<group>"; };
 		2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainProperties.swift; sourceTree = "<group>"; };
 		2CE552342E268F9E004BE9AF /* Meme-release.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Meme-release.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE552372E268F9E004BE9AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -98,6 +101,7 @@
 		2CC399972E2F830500D14084 /* KeyChain */ = {
 			isa = PBXGroup;
 			children = (
+				2CC399982E2F831100D14084 /* KeyChainStorable.swift */,
 				2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */,
 			);
 			path = KeyChain;
@@ -400,6 +404,8 @@
 				AD848E3A2E2C93D40003F09F /* LobbyRepository.swift in Sources */,
 				AD848E402E2C94660003F09F /* LobbyInterface.swift in Sources */,
 				AD848E372E2C93790003F09F /* LobbyResponse.swift in Sources */,
+				2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
+				2CC399992E2F831100D14084 /* KeyChainStorable.swift in Sources */,
 				2CE552382E268F9E004BE9AF /* AppDelegate.swift in Sources */,
 				2CE5523A2E268F9E004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E432E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,
@@ -421,6 +427,7 @@
 				AD848E3F2E2C94660003F09F /* LobbyInterface.swift in Sources */,
 				AD848E362E2C93790003F09F /* LobbyResponse.swift in Sources */,
 				2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
+				2CC3999A2E2F831100D14084 /* KeyChainStorable.swift in Sources */,
 				2CE5524E2E269159004BE9AF /* AppDelegate.swift in Sources */,
 				2CE5524F2E269159004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E422E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,

--- a/Meme/Meme.xcodeproj/project.pbxproj
+++ b/Meme/Meme.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		2CC3999A2E2F831100D14084 /* KeyChainStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399982E2F831100D14084 /* KeyChainStorable.swift */; };
 		2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
 		2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
+		2CC399A22E2F85AB00D14084 /* KeyChainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399A12E2F85AB00D14084 /* KeyChainError.swift */; };
+		2CC399A32E2F85AB00D14084 /* KeyChainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399A12E2F85AB00D14084 /* KeyChainError.swift */; };
 		2CE552382E268F9E004BE9AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552372E268F9E004BE9AF /* AppDelegate.swift */; };
 		2CE5523A2E268F9E004BE9AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552392E268F9E004BE9AF /* SceneDelegate.swift */; };
 		2CE5523C2E268F9E004BE9AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE5523B2E268F9E004BE9AF /* ViewController.swift */; };
@@ -52,6 +54,7 @@
 /* Begin PBXFileReference section */
 		2CC399982E2F831100D14084 /* KeyChainStorable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainStorable.swift; sourceTree = "<group>"; };
 		2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainProperties.swift; sourceTree = "<group>"; };
+		2CC399A12E2F85AB00D14084 /* KeyChainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainError.swift; sourceTree = "<group>"; };
 		2CE552342E268F9E004BE9AF /* Meme-release.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Meme-release.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE552372E268F9E004BE9AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2CE552392E268F9E004BE9AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -103,6 +106,7 @@
 			children = (
 				2CC399982E2F831100D14084 /* KeyChainStorable.swift */,
 				2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */,
+				2CC399A12E2F85AB00D14084 /* KeyChainError.swift */,
 			);
 			path = KeyChain;
 			sourceTree = "<group>";

--- a/Meme/Meme.xcodeproj/project.pbxproj
+++ b/Meme/Meme.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		2CC399992E2F831100D14084 /* KeyChainStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399982E2F831100D14084 /* KeyChainStorable.swift */; };
 		2CC3999A2E2F831100D14084 /* KeyChainStorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399982E2F831100D14084 /* KeyChainStorable.swift */; };
+		2CC3999C2E2F848800D14084 /* KeyChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999B2E2F848800D14084 /* KeyChainStore.swift */; };
+		2CC3999D2E2F848800D14084 /* KeyChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999B2E2F848800D14084 /* KeyChainStore.swift */; };
 		2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
 		2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
 		2CC399A22E2F85AB00D14084 /* KeyChainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC399A12E2F85AB00D14084 /* KeyChainError.swift */; };
@@ -53,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		2CC399982E2F831100D14084 /* KeyChainStorable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainStorable.swift; sourceTree = "<group>"; };
+		2CC3999B2E2F848800D14084 /* KeyChainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainStore.swift; sourceTree = "<group>"; };
 		2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainProperties.swift; sourceTree = "<group>"; };
 		2CC399A12E2F85AB00D14084 /* KeyChainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainError.swift; sourceTree = "<group>"; };
 		2CE552342E268F9E004BE9AF /* Meme-release.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Meme-release.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -105,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				2CC399982E2F831100D14084 /* KeyChainStorable.swift */,
+				2CC3999B2E2F848800D14084 /* KeyChainStore.swift */,
 				2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */,
 				2CC399A12E2F85AB00D14084 /* KeyChainError.swift */,
 			);
@@ -402,6 +406,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2CC3999C2E2F848800D14084 /* KeyChainStore.swift in Sources */,
 				2CE5523C2E268F9E004BE9AF /* ViewController.swift in Sources */,
 				AD848E262E2B55CF0003F09F /* APIConfiguration.swift in Sources */,
 				AD848E462E2C9BEC0003F09F /* Lobby.swift in Sources */,
@@ -410,6 +415,7 @@
 				AD848E372E2C93790003F09F /* LobbyResponse.swift in Sources */,
 				2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
 				2CC399992E2F831100D14084 /* KeyChainStorable.swift in Sources */,
+				2CC399A32E2F85AB00D14084 /* KeyChainError.swift in Sources */,
 				2CE552382E268F9E004BE9AF /* AppDelegate.swift in Sources */,
 				2CE5523A2E268F9E004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E432E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,
@@ -424,6 +430,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2CC3999D2E2F848800D14084 /* KeyChainStore.swift in Sources */,
 				2CE5524D2E269159004BE9AF /* ViewController.swift in Sources */,
 				AD848E272E2B55CF0003F09F /* APIConfiguration.swift in Sources */,
 				AD848E452E2C9BEC0003F09F /* Lobby.swift in Sources */,
@@ -432,6 +439,7 @@
 				AD848E362E2C93790003F09F /* LobbyResponse.swift in Sources */,
 				2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
 				2CC3999A2E2F831100D14084 /* KeyChainStorable.swift in Sources */,
+				2CC399A22E2F85AB00D14084 /* KeyChainError.swift in Sources */,
 				2CE5524E2E269159004BE9AF /* AppDelegate.swift in Sources */,
 				2CE5524F2E269159004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E422E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,

--- a/Meme/Meme.xcodeproj/project.pbxproj
+++ b/Meme/Meme.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
+		2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */; };
 		2CE552382E268F9E004BE9AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552372E268F9E004BE9AF /* AppDelegate.swift */; };
 		2CE5523A2E268F9E004BE9AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552392E268F9E004BE9AF /* SceneDelegate.swift */; };
 		2CE5523C2E268F9E004BE9AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE5523B2E268F9E004BE9AF /* ViewController.swift */; };
@@ -46,6 +48,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainProperties.swift; sourceTree = "<group>"; };
 		2CE552342E268F9E004BE9AF /* Meme-release.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Meme-release.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE552372E268F9E004BE9AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2CE552392E268F9E004BE9AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -92,6 +95,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2CC399972E2F830500D14084 /* KeyChain */ = {
+			isa = PBXGroup;
+			children = (
+				2CC3999E2E2F84BD00D14084 /* KeyChainProperties.swift */,
+			);
+			path = KeyChain;
+			sourceTree = "<group>";
+		};
 		2CE5522B2E268F9E004BE9AF = {
 			isa = PBXGroup;
 			children = (
@@ -115,6 +126,7 @@
 			children = (
 				AD848E112E2B42F30003F09F /* Sources */,
 				AD848E122E2B42F90003F09F /* Resources */,
+				2CC399972E2F830500D14084 /* KeyChain */
 			);
 			path = Meme;
 			sourceTree = "<group>";
@@ -408,6 +420,7 @@
 				AD848E392E2C93D40003F09F /* LobbyRepository.swift in Sources */,
 				AD848E3F2E2C94660003F09F /* LobbyInterface.swift in Sources */,
 				AD848E362E2C93790003F09F /* LobbyResponse.swift in Sources */,
+				2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
 				2CE5524E2E269159004BE9AF /* AppDelegate.swift in Sources */,
 				2CE5524F2E269159004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E422E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,

--- a/Meme/Meme/KeyChain/KeyChainError.swift
+++ b/Meme/Meme/KeyChain/KeyChainError.swift
@@ -1,0 +1,17 @@
+//
+//  KeyChainError.swift
+//  Meme
+//
+//  Created by 임현규 on 7/22/25.
+//
+
+import Foundation
+
+enum KeyChainError: Error {
+    case notFound(property: KeyChainProperties, status: OSStatus)
+    case saveFaild(property: KeyChainProperties, status: OSStatus)
+    case loadFaild(property: KeyChainProperties, status: OSStatus)
+    case deleteFaild(property: KeyChainProperties, status: OSStatus)
+    
+    case keychainDataEncodingFaild(result: AnyObject?)
+}

--- a/Meme/Meme/KeyChain/KeyChainProperties.swift
+++ b/Meme/Meme/KeyChain/KeyChainProperties.swift
@@ -1,0 +1,11 @@
+//
+//  KeyChainProperties.swift
+//  Meme
+//
+//  Created by 임현규 on 7/22/25.
+//
+
+enum KeyChainProperties: String, CaseIterable {
+    case accessToken = "ACCESS-TOKEN"
+    case refreshToken = "REFRESH-TOKEN"
+}

--- a/Meme/Meme/KeyChain/KeyChainStorable.swift
+++ b/Meme/Meme/KeyChain/KeyChainStorable.swift
@@ -1,0 +1,13 @@
+//
+//  KeyChainStorable.swift
+//  Meme
+//
+//  Created by 임현규 on 7/22/25.
+//
+
+protocol KeyChainStorable {
+    func save(property: KeyChainProperties, value: String) throws
+    func load(property: KeyChainProperties) throws -> String
+    func delete(property: KeyChainProperties) throws
+    func deleteAll() throws
+}

--- a/Meme/Meme/KeyChain/KeyChainStore.swift
+++ b/Meme/Meme/KeyChain/KeyChainStore.swift
@@ -1,0 +1,84 @@
+//
+//  KeyChainStore.swift
+//  Meme
+//
+//  Created by 임현규 on 7/22/25.
+//
+
+import Foundation
+
+struct KeyChainStore: KeyChainStorable {
+    
+    // MARK: - Singleton Instance
+    
+    static let shared = KeyChainStore()
+    
+    // MARK: - Methods
+    
+    func save(property: KeyChainProperties, value: String) throws {
+        let query: NSDictionary = [
+            kSecClass : kSecClassGenericPassword,
+            kSecAttrAccount : property.rawValue,
+            kSecValueData : value.data(using: .utf8, allowLossyConversion: false) ?? .init()
+        ]
+        
+        let deleteState = SecItemDelete(query)
+        let addState = SecItemAdd(query, nil)
+        
+        if deleteState == errSecSuccess {
+            print("keychain delete success - [\(property.rawValue) : \(value)]")
+        } else if deleteState != errSecItemNotFound {
+            throw KeyChainError.deleteFaild(property: property, status: deleteState)
+        }
+        
+        if addState == errSecSuccess {
+            print("keychain save success - [\(property.rawValue) : \(value)]")
+        } else {
+            throw KeyChainError.saveFaild(property: property, status: addState)
+        }
+    }
+    
+    
+    func load(property: KeyChainProperties) throws -> String {
+        let query: NSDictionary = [
+            kSecClass : kSecClassGenericPassword,
+            kSecAttrAccount : property.rawValue,
+            kSecReturnData : kCFBooleanTrue!,
+            kSecMatchLimit : kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query, &result)
+        
+        if status == errSecIO {
+            guard let data = result as? Data,
+                  let result = String(data: data, encoding: .utf8)
+            else { throw KeyChainError.keychainDataEncodingFaild(result: result) }
+            print("keychain load success - \(result)")
+            return result
+        } else if status == errSecItemNotFound {
+            throw KeyChainError.notFound(property: property, status: status)
+        } else {
+            throw KeyChainError.loadFaild(property: property, status: status)
+        }
+    }
+    
+    func delete(property: KeyChainProperties) throws {
+        let query: NSDictionary = [
+            kSecClass : kSecClassGenericPassword,
+            kSecAttrAccount : property.rawValue
+        ]
+        
+        let status = SecItemDelete(query)
+        
+        if status != errSecSuccess {
+            throw KeyChainError.deleteFaild(property: property, status: status)
+        }
+    }
+    
+    func deleteAll() throws {
+        try KeyChainProperties.allCases.forEach { _ in
+            try delete(property: .accessToken)
+        }
+    }
+}


### PR DESCRIPTION
## 작업한 내용
- KeyChain을 통한 값 관리 객체 구현 (KeyChainStore)

## 전달 사항
- 일단 acessToken, refreshToken만 선언해놨음!
- save(), load(), delete(), deleteAll() 메소드에서 keyChain에서 status에 따라 에러 던지도록 처리함 

## 관련 이슈
Resolved: https://github.com/Nexters/meme-wiki-iOS/issues/8