### PR TITLE
feat: 웹뷰브릿지, 웹뷰컨트롤러 셋업

### DIFF
--- a/Meme/Meme.xcodeproj/project.pbxproj
+++ b/Meme/Meme.xcodeproj/project.pbxproj
@@ -33,6 +33,12 @@
 		2CE5526A2E292245004BE9AF /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE552692E292245004BE9AF /* Kingfisher */; };
 		2CE552732E2B6EEA004BE9AF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552722E2B6EEA004BE9AF /* Logger.swift */; };
 		2CE552742E2B6EEA004BE9AF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE552722E2B6EEA004BE9AF /* Logger.swift */; };
+		AD5194602E346D1E0069D29B /* WikiWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD51945F2E346D1E0069D29B /* WikiWebViewController.swift */; };
+		AD5194612E346D1E0069D29B /* WikiWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD51945F2E346D1E0069D29B /* WikiWebViewController.swift */; };
+		AD5194632E346D3D0069D29B /* WikiScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5194622E346D3D0069D29B /* WikiScriptMessageHandler.swift */; };
+		AD5194642E346D3D0069D29B /* WikiScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5194622E346D3D0069D29B /* WikiScriptMessageHandler.swift */; };
+		AD5194672E346F770069D29B /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5194662E346F770069D29B /* String+Extension.swift */; };
+		AD5194682E346F770069D29B /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5194662E346F770069D29B /* String+Extension.swift */; };
 		AD848E162E2B49620003F09F /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD848E152E2B49620003F09F /* ErrorResponse.swift */; };
 		AD848E172E2B49620003F09F /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD848E152E2B49620003F09F /* ErrorResponse.swift */; };
 		AD848E1D2E2B4A430003F09F /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD848E1C2E2B4A430003F09F /* Endpoint.swift */; };
@@ -69,6 +75,9 @@
 		2CE552592E26928D004BE9AF /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		2CE5525A2E269298004BE9AF /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		2CE552722E2B6EEA004BE9AF /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		AD51945F2E346D1E0069D29B /* WikiWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiWebViewController.swift; sourceTree = "<group>"; };
+		AD5194622E346D3D0069D29B /* WikiScriptMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiScriptMessageHandler.swift; sourceTree = "<group>"; };
+		AD5194662E346F770069D29B /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		AD848E152E2B49620003F09F /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		AD848E1C2E2B4A430003F09F /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		AD848E252E2B55CF0003F09F /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
@@ -138,7 +147,7 @@
 			children = (
 				AD848E112E2B42F30003F09F /* Sources */,
 				AD848E122E2B42F90003F09F /* Resources */,
-				2CC399972E2F830500D14084 /* KeyChain */
+				2CC399972E2F830500D14084 /* KeyChain */,
 			);
 			path = Meme;
 			sourceTree = "<group>";
@@ -154,8 +163,26 @@
 			isa = PBXGroup;
 			children = (
 				2CE552722E2B6EEA004BE9AF /* Logger.swift */,
+				AD5194662E346F770069D29B /* String+Extension.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		AD51945E2E346CF80069D29B /* Bridge */ = {
+			isa = PBXGroup;
+			children = (
+				AD5194622E346D3D0069D29B /* WikiScriptMessageHandler.swift */,
+			);
+			path = Bridge;
+			sourceTree = "<group>";
+		};
+		AD5194652E346E240069D29B /* Web */ = {
+			isa = PBXGroup;
+			children = (
+				AD51945F2E346D1E0069D29B /* WikiWebViewController.swift */,
+				AD51945E2E346CF80069D29B /* Bridge */,
+			);
+			path = Web;
 			sourceTree = "<group>";
 		};
 		AD848E112E2B42F30003F09F /* Sources */ = {
@@ -186,6 +213,7 @@
 		AD848E132E2B45350003F09F /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				AD5194652E346E240069D29B /* Web */,
 				AD848E222E2B559B0003F09F /* API */,
 			);
 			path = Base;
@@ -414,9 +442,12 @@
 				AD848E402E2C94660003F09F /* LobbyInterface.swift in Sources */,
 				AD848E372E2C93790003F09F /* LobbyResponse.swift in Sources */,
 				2CC3999F2E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
+				AD5194682E346F770069D29B /* String+Extension.swift in Sources */,
+				AD5194632E346D3D0069D29B /* WikiScriptMessageHandler.swift in Sources */,
 				2CC399992E2F831100D14084 /* KeyChainStorable.swift in Sources */,
 				2CC399A32E2F85AB00D14084 /* KeyChainError.swift in Sources */,
 				2CE552382E268F9E004BE9AF /* AppDelegate.swift in Sources */,
+				AD5194612E346D1E0069D29B /* WikiWebViewController.swift in Sources */,
 				2CE5523A2E268F9E004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E432E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,
 				AD848E1D2E2B4A430003F09F /* Endpoint.swift in Sources */,
@@ -438,9 +469,12 @@
 				AD848E3F2E2C94660003F09F /* LobbyInterface.swift in Sources */,
 				AD848E362E2C93790003F09F /* LobbyResponse.swift in Sources */,
 				2CC399A02E2F84BD00D14084 /* KeyChainProperties.swift in Sources */,
+				AD5194672E346F770069D29B /* String+Extension.swift in Sources */,
+				AD5194642E346D3D0069D29B /* WikiScriptMessageHandler.swift in Sources */,
 				2CC3999A2E2F831100D14084 /* KeyChainStorable.swift in Sources */,
 				2CC399A22E2F85AB00D14084 /* KeyChainError.swift in Sources */,
 				2CE5524E2E269159004BE9AF /* AppDelegate.swift in Sources */,
+				AD5194602E346D1E0069D29B /* WikiWebViewController.swift in Sources */,
 				2CE5524F2E269159004BE9AF /* SceneDelegate.swift in Sources */,
 				AD848E422E2C9B2A0003F09F /* LobbyUseCase.swift in Sources */,
 				AD848E1E2E2B4A430003F09F /* Endpoint.swift in Sources */,

--- a/Meme/Meme/Sources/Base/Web/Bridge/WikiScriptMessageHandler.swift
+++ b/Meme/Meme/Sources/Base/Web/Bridge/WikiScriptMessageHandler.swift
@@ -29,6 +29,7 @@ class WikiScriptMessageHandler: NSObject, WKScriptMessageHandler {
         case .share:
             let method = parameters["method"] as? String
             let link = (parameters["link"] as? String)?.asEncodedURL()
+            // TODO: - share
         }
     }
 }

--- a/Meme/Meme/Sources/Base/Web/Bridge/WikiScriptMessageHandler.swift
+++ b/Meme/Meme/Sources/Base/Web/Bridge/WikiScriptMessageHandler.swift
@@ -1,0 +1,39 @@
+//
+//  WikiScriptMessageHandler.swift
+//  Meme
+//
+//  Created by 제나 on 7/26/25.
+//
+
+import WebKit
+
+class WikiScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    private weak var viewController: UIViewController?
+    
+    init(viewController: UIViewController? = nil) {
+        self.viewController = viewController
+    }
+    
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard let parameters = message.body as? [String: Any],
+              let command = parameters["command"] as? String, // TODO: - command?
+              let handlerName = WikiScriptMessageHandlerName(rawValue: command)
+        else { return }
+        
+        switch handlerName {
+        case .close:
+            return
+        case .share:
+            let method = parameters["method"] as? String
+            let link = (parameters["link"] as? String)?.asEncodedURL()
+        }
+    }
+}
+
+enum WikiScriptMessageHandlerName: String, CaseIterable {
+    case close
+    case share
+}

--- a/Meme/Meme/Sources/Base/Web/Bridge/WikiScriptMessageHandler.swift
+++ b/Meme/Meme/Sources/Base/Web/Bridge/WikiScriptMessageHandler.swift
@@ -25,6 +25,7 @@ class WikiScriptMessageHandler: NSObject, WKScriptMessageHandler {
         
         switch handlerName {
         case .close:
+            Log.debug(">>> close", .networking)
             return
         case .share:
             let method = parameters["method"] as? String

--- a/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
+++ b/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
@@ -58,11 +58,12 @@ extension WikiWebViewController: WKUIDelegate, WKNavigationDelegate {
     private var configuration: WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.allowsAirPlayForMediaPlayback = true
+        configuration.userContentController = userContentController
         return configuration
     }
     private var userContentController: WKUserContentController {
         let contentController = WKUserContentController()
-        contentController.add(wikiScriptMessageHandler, contentWorld: .page, name: "MemeWiki")
+        contentController.add(wikiScriptMessageHandler, name: "wikiHandler")
         return contentController
     }
     private var wikiScriptMessageHandler: WKScriptMessageHandler {

--- a/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
+++ b/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
@@ -40,6 +40,9 @@ extension WikiWebViewController: WKUIDelegate, WKNavigationDelegate {
         webView.uiDelegate = self
         webView.navigationDelegate = self
         webView.allowsBackForwardNavigationGestures = true
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
         
         view.addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = false

--- a/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
+++ b/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
@@ -22,6 +22,7 @@ class WikiWebViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupWebView()
     }
     
     private func setupWebView() {
@@ -52,7 +53,7 @@ extension WikiWebViewController: WKUIDelegate, WKNavigationDelegate {
         return webView
     }
     private var configuration: WKWebViewConfiguration {
-        var configuration = WKWebViewConfiguration()
+        let configuration = WKWebViewConfiguration()
         configuration.allowsAirPlayForMediaPlayback = true
         return configuration
     }

--- a/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
+++ b/Meme/Meme/Sources/Base/Web/WikiWebViewController.swift
@@ -1,0 +1,67 @@
+//
+//  WikiWebViewController.swift
+//  Meme-release
+//
+//  Created by 제나 on 7/26/25.
+//
+
+import WebKit
+
+class WikiWebViewController: UIViewController {
+    let url: URL
+    var webViews = [WKWebView]()
+    
+    init(url: URL) {
+        self.url = url
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(code:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    private func setupWebView() {
+        let webView = createWebView(frame: view.frame, configuration: configuration)
+        load(url, in: webView)
+    }
+    private func load(_ url: URL, in webView: WKWebView) {
+        webView.load(URLRequest(url: url))
+    }
+}
+
+extension WikiWebViewController: WKUIDelegate, WKNavigationDelegate {
+    private func createWebView(frame: CGRect, configuration: WKWebViewConfiguration) -> WKWebView {
+        let webView = WKWebView(frame: frame, configuration: configuration)
+        webView.uiDelegate = self
+        webView.navigationDelegate = self
+        webView.allowsBackForwardNavigationGestures = true
+        
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+        webViews.append(webView)
+        return webView
+    }
+    private var configuration: WKWebViewConfiguration {
+        var configuration = WKWebViewConfiguration()
+        configuration.allowsAirPlayForMediaPlayback = true
+        return configuration
+    }
+    private var userContentController: WKUserContentController {
+        let contentController = WKUserContentController()
+        contentController.add(wikiScriptMessageHandler, contentWorld: .page, name: "MemeWiki")
+        return contentController
+    }
+    private var wikiScriptMessageHandler: WKScriptMessageHandler {
+        return WikiScriptMessageHandler()
+    }
+}

--- a/Meme/Meme/Sources/SceneDelegate.swift
+++ b/Meme/Meme/Sources/SceneDelegate.swift
@@ -10,12 +10,12 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    var navigationController: UINavigationController?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = ViewController()
+        window.rootViewController = UINavigationController(rootViewController: ViewController())
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/Meme/Meme/Sources/Utils/String+Extension.swift
+++ b/Meme/Meme/Sources/Utils/String+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  String+Extension.swift
+//  Meme
+//
+//  Created by 제나 on 7/26/25.
+//
+
+import Foundation
+
+extension String {
+    func asEncodedURL() -> URL? {
+        let urlString = trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        if let url = URL(string: urlString) {
+            return url
+        } else if let encoded = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                  let url = URL(string: encoded) {
+            return url
+        }
+        return nil
+    }
+}

--- a/Meme/Meme/Sources/ViewController.swift
+++ b/Meme/Meme/Sources/ViewController.swift
@@ -10,7 +10,7 @@ import Alamofire
 import Moya
 import Kingfisher
 
-class ViewController: UIViewController {
+class ViewController: UINavigationController {
     
     private let label: UILabel = {
         let label = UILabel()
@@ -33,6 +33,13 @@ class ViewController: UIViewController {
             label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            guard let url = "http://google.com".asEncodedURL() else { return }
+            let webViewController = WikiWebViewController(url: url)
+            self?.pushViewController(webViewController, animated: true)
+        
+        }
     }
 }
 

--- a/Meme/Meme/Sources/ViewController.swift
+++ b/Meme/Meme/Sources/ViewController.swift
@@ -6,17 +6,26 @@
 //
 
 import UIKit
+import Combine
 import Alamofire
 import Moya
 import Kingfisher
 
-class ViewController: UINavigationController {
+class ViewController: UIViewController {
+    
+    private let subscrpitions = Set<AnyCancellable>()
     
     private let label: UILabel = {
         let label = UILabel()
         let labelText = Bundle.main.object(forInfoDictionaryKey: "APP_LABEL_TEXT") as? String
         label.text = labelText
         return label
+    }()
+    
+    private let testWebViewButton: UIButton = {
+        let button = UIButton(configuration: .filled())
+        button.setTitle("open webView", for: .normal)
+        return button
     }()
     
     override func viewDidLoad() {
@@ -34,12 +43,25 @@ class ViewController: UINavigationController {
             label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            guard let url = "http://google.com".asEncodedURL() else { return }
-            let webViewController = WikiWebViewController(url: url)
-            self?.pushViewController(webViewController, animated: true)
-        
+        view.addSubview(testWebViewButton)
+        testWebViewButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            testWebViewButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            testWebViewButton.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 10)
+        ])
+        setupButton()
+    }
+    
+    private func setupButton() {
+        let action = UIAction { [weak self] _ in
+            self?.openWebView()
         }
+        testWebViewButton.addAction(action, for: .touchUpInside)
+    }
+    private func openWebView() {
+        guard let url = URL(string: "https://google.com") else { return }
+        let webViewController = WikiWebViewController(url: url)
+        navigationController?.pushViewController(webViewController, animated: true)
     }
 }
 


### PR DESCRIPTION
# 작업한 내용
웹과 통신할 수 있는 브릿지를 만들고 기본 웹뷰컨트롤러를 세팅합니다
아마도 앱 > 웹에서 명령을 보낼 일은 없을 것 같아서 reply를 보내지 않는 핸들러로 만들었어요
나중에 스펙 추가되면 replyHandler를 날리는 애로 변경하면 될 것 같습니다~!

# 전달 사항
테스트용으로 웹뷰여는 버튼 하나 추가해두었습니다
우리는 공유 관련 명령만 쓰겠지만 테스트용으로 close 넣어봤슴다
커맨드넘겨보면 로깅하는 것까지 확완!
`window.webkit.messageHandlers.wikiHandler.postMessage({ command: "close" });`

<img width="1035" height="944" alt="스크린샷 2025-07-26 오후 3 52 55" src="https://github.com/user-attachments/assets/6645e74f-61bc-42bf-a79f-44c0b8136fa4" />


# 관련 이슈
close #5 